### PR TITLE
Rename project to fix update notifications.

### DIFF
--- a/autotag.info
+++ b/autotag.info
@@ -3,4 +3,4 @@ description = "Auto-scans content for relevant tags from vocabularies and provid
 core = "7.x"
 package = "Taxonomy"
 dependencies[] = "taxonomy"
-project = "autotag"
+project = "autotag_drupalninja"


### PR DESCRIPTION
The project name collides with the upstream project, causing update notifications to produce bizarre results.
